### PR TITLE
#24 Divide Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: "[Type 2: \U0001F41B Bug Report]"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### 🛠 Environment
+
+- Android OS Version
+
+- Device
+
+  
+
+### 🐛 Problem
+
+- Describe the problem or defect that you faced
+
+  
+
+### 🔍️ Solution
+
+- Describe the clear and concise solution or feature you need
+
+  
+
+### 🔗 Reference (optional)
+
+- additional links, screenshots, videos ... etc

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: "[Type 1 : ✅ Feature]"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### 🔍️ Description
+
+- describe the feature
+
+  
+
+### 📌 Tasks 
+
+- [ ] task1
+- [ ] task2
+- [ ] task3


### PR DESCRIPTION
### 🎯 Related issue
- #24 

### 🛠 Implementation

#### 🔍️ summary
- Divide Issue Templates by issue types (type 1: feature, type 2: bug report)
- The templates will be set by the types user choose

#### 📌 tasks 

- [x] Create Type 1 Issue Template
- [x] Create Type 2 Issue Template
